### PR TITLE
fix #37 set copy warning

### DIFF
--- a/cobra/preprocessing/preprocessor.py
+++ b/cobra/preprocessing/preprocessor.py
@@ -227,6 +227,9 @@ class PreProcessor(BaseEstimator):
         log.info("Starting to fit pipeline")
         start = time.time()
 
+        # Ensure to operate on separate copy of data
+        train_data = train_data.copy()
+
         # Fit discretizer, categorical preprocessor & target encoder
         # Note that in order to fit target_encoder, we first have to transform
         # the data using the fitted discretizer & categorical_data_processor


### PR DESCRIPTION
Fixes warning `A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_index,col_indexer] = value instead`

The issue was actually in how Cobra is used, not the code. In the documentation, we do the following:

```python
# fit the pipeline (will automatically be stored to "path" variable)
preprocessor.fit(basetable[basetable["split"]=="train"],
                 continuous_vars=continuous_vars,
                 discrete_vars=discrete_vars,
                 target_column_name=target_column_name)
```

You notice that first parameter, where we are passing slice of a dataframe. When we further operate on that dataframe (adding features), the warning is triggered, since we are working with a slice.

**Solution**
Enforce `.copy()` of the dataframe before we work with it, inside cobra.

Source of the warning:  https://stackoverflow.com/questions/20625582/how-to-deal-with-settingwithcopywarning-in-pandas