### PR TITLE
Forward feature selection: Linear regression requires "lower is better" comparison of RMSE.

### DIFF
--- a/cobra/model_building/forward_selection.py
+++ b/cobra/model_building/forward_selection.py
@@ -10,7 +10,6 @@ log = logging.getLogger(__name__)
 
 
 class ForwardFeatureSelection:
-
     """Perform forward feature selection for a given dataset using a given
     algorithm.
 
@@ -22,17 +21,14 @@ class ForwardFeatureSelection:
         Maximum number of predictors allowed in any model. This corresponds
         more or less with the maximum number of steps in the forward feature
         selection.
-    model_name : str
-        Name of the model to use for forward feature selection.
     pos_only : bool
         Whether or not the model coefficients should all be positive.
     """
 
     def __init__(self,
-                 model_type: str="classification",
-                 max_predictors: int=50,
-                 model_name: str="logistic-regression",
-                 pos_only: bool=True):
+                 model_type: str = "classification",
+                 max_predictors: int = 50,
+                 pos_only: bool = True):
 
         if model_type == "classification":
             self.MLModel = LogisticRegressionModel
@@ -40,7 +36,6 @@ class ForwardFeatureSelection:
             self.MLModel = LinearRegressionModel
 
         self.max_predictors = max_predictors
-        self.model_name = model_name
         self.pos_only = pos_only
 
         self._fitted_models = []
@@ -70,7 +65,8 @@ class ForwardFeatureSelection:
 
     def compute_model_performances(self, data: pd.DataFrame,
                                    target_column_name: str,
-                                   splits: list = ["train", "selection", "validation"]
+                                   splits: list = ["train", "selection",
+                                                   "validation"]
                                    ) -> pd.DataFrame:
         """Compute for each model the performance for different sets (e.g.
         train-selection-validation) and return them along with a list of
@@ -96,7 +92,6 @@ class ForwardFeatureSelection:
         results = []
         predictor_set = set([])
         for model in self._fitted_models:
-
             last_added_predictor = (set(model.predictors)
                                     .difference(predictor_set))
             tmp = {
@@ -111,7 +106,7 @@ class ForwardFeatureSelection:
                     data[data["split"] == split],
                     data[data["split"] == split][target_column_name],
                     split=split  # parameter used for caching
-                    )
+                )
                 for split in splits
             })
 
@@ -128,7 +123,7 @@ class ForwardFeatureSelection:
 
         Parameters
         ----------
-        data : pd.DataFrame
+        train_data : pd.DataFrame
             Data on which to fit the model.
         target_column_name : str
             Name of the target column.
@@ -170,9 +165,9 @@ class ForwardFeatureSelection:
 
     def _forward_selection(self, train_data: pd.DataFrame,
                            target_column_name: str, predictors: list,
-                           forced_predictors: list=[]) -> list:
+                           forced_predictors: list = []) -> list:
         """Perform the forward feature selection algorithm to compute a list
-        of models (with increasing performance?). The length of the list,
+        of models (with increasing performance). The length of the list,
         i.e. the number of models is bounded by the max_predictors class
         attribute.
 
@@ -231,7 +226,7 @@ class ForwardFeatureSelection:
                               candidate_predictors: list,
                               current_predictors: list):
         """Given a list of current predictors which are already selected to
-        be include in the model, Find amongst a list candidate predictors
+        be include in the model, find amongst a list candidate predictors
         the predictor to add to the selected list so that the resulting model
         has the best performance.
 
@@ -253,25 +248,36 @@ class ForwardFeatureSelection:
         """
         # placeholders
         best_model = None
-        best_performance = -1
+        if self.MLModel == LogisticRegressionModel:
+            best_performance = -1  # AUC metric is used.
+        elif self.MLModel == LinearRegressionModel:
+            best_performance = float("inf")  # RMSE metric is used.
+        else:
+            raise ValueError("No metric comparison method has been configured "
+                             "for the given model_type specified as "
+                             "ForwardFeatureSelection argument.")
 
         for pred in candidate_predictors:
-
-            # train model with additional predictor
+            # Train a model with an additional predictor
             model = self._train_model(train_data, target_column_name,
                                       (current_predictors + [pred]))
-            # Evaluate model
+            # Evaluate the model
             performance = (model
                            .evaluate(train_data[current_predictors + [pred]],
                                      train_data[target_column_name],
                                      split="train"))
 
-            if (self.pos_only and (not (model.get_coef() >= 0).all())):
+            if self.pos_only and (not (model.get_coef() >= 0).all()):
                 continue
 
-            # check if model is better than current best model
-            # and if yes, replace current best!
-            if (performance >= best_performance):
+            # Check if the model is better than the current best model
+            # and if it is, replace the current best.
+            if self.MLModel == LogisticRegressionModel \
+                    and performance > best_performance:  # AUC metric is used.
+                best_performance = performance
+                best_model = model
+            elif self.MLModel == LinearRegressionModel \
+                    and performance < best_performance:  # RMSE metric is used.
                 best_performance = performance
                 best_model = model
 


### PR DESCRIPTION
# Story Title

[Forward feature selection: Linear regression requires "lower is better" comparison of RMSE.](https://github.com/PythonPredictions/cobra/issues/70)

## Changes made

- extended _find_next_best_model() in forward feature selection to compare models in "lower is better" fashion on the RMSE metric.
- changed the comparison logic from `performance >= best_performance` to `performance > best_performance` (regression example): to me it seems adding a next best model is pointless if it just performs _as good_ as the previous selected feature... (or do I miss something?)
- removed unused model_type argument of ForwardFeatureSelection

## How does the solution address the problem

This PR will prevent crazy stuff from happening in forward feature selection! Aliens will stay home and no longer attack our lovely performance curves!

## Linked issues

Resolves #70 