### PR TITLE
Remove FutureWarnings due to pandas 2.0

### DIFF
--- a/cobra/preprocessing/categorical_data_processor.py
+++ b/cobra/preprocessing/categorical_data_processor.py
@@ -309,10 +309,10 @@ class CategoricalDataProcessor(BaseEstimator):
         """
 
         column_name_clean = column_name + "_processed"
-        data.loc[:, column_name_clean] = data[column_name].astype(object)
+        data[column_name_clean] = data[column_name].astype(object)
 
         # Fill missings first
-        data.loc[:, column_name_clean] = (CategoricalDataProcessor
+        data[column_name_clean] = (CategoricalDataProcessor
                                           ._replace_missings(
                                               data,
                                               column_name_clean
@@ -329,14 +329,14 @@ class CategoricalDataProcessor(BaseEstimator):
                                 "and will be skipped".format(column_name))
                 return data
 
-            data.loc[:, column_name_clean] = (CategoricalDataProcessor
+            data[column_name_clean] = (CategoricalDataProcessor
                                               ._replace_categories(
                                                   data[column_name_clean],
                                                   categories,
                                                   self.regroup_name))
 
         # change data to categorical
-        data.loc[:, column_name_clean] = (data[column_name_clean]
+        data[column_name_clean] = (data[column_name_clean]
                                           .astype("category"))
 
         return data

--- a/cobra/preprocessing/kbins_discretizer.py
+++ b/cobra/preprocessing/kbins_discretizer.py
@@ -327,7 +327,7 @@ class KBinsDiscretizer(BaseEstimator):
         if data[column_name_bin].isnull().sum() > 0:
 
             # Add an additional bin for missing values
-            data[column_name_bin]=data[column_name_bin].cat.add_categories(["Missing"])
+            data[column_name_bin].cat.add_categories(["Missing"], inplace=True)
 
             # Replace NULL with "Missing"
             # Otherwise these will be ignored in groupby

--- a/cobra/preprocessing/kbins_discretizer.py
+++ b/cobra/preprocessing/kbins_discretizer.py
@@ -327,7 +327,7 @@ class KBinsDiscretizer(BaseEstimator):
         if data[column_name_bin].isnull().sum() > 0:
 
             # Add an additional bin for missing values
-            data[column_name_bin].cat.add_categories(["Missing"], inplace=True)
+            data[column_name_bin]=data[column_name_bin].cat.add_categories(["Missing"])
 
             # Replace NULL with "Missing"
             # Otherwise these will be ignored in groupby

--- a/cobra/preprocessing/kbins_discretizer.py
+++ b/cobra/preprocessing/kbins_discretizer.py
@@ -315,13 +315,13 @@ class KBinsDiscretizer(BaseEstimator):
         column_name_bin = column_name + "_bin"
 
         # use pd.cut to compute bins
-        data.loc[:, column_name_bin] = pd.cut(x=data[column_name],
+        data[column_name_bin] = pd.cut(x=data[column_name],
                                               bins=interval_idx)
 
         # Rename bins so that the output has a proper format
         bin_labels = self._create_bin_labels(bins)
 
-        data.loc[:, column_name_bin] = (data[column_name_bin]
+        data[column_name_bin] = (data[column_name_bin]
                                         .cat.rename_categories(bin_labels))
 
         if data[column_name_bin].isnull().sum() > 0:

--- a/tests/preprocessing/test_preprocessor.py
+++ b/tests/preprocessing/test_preprocessor.py
@@ -35,7 +35,7 @@ class TestPreProcessor:
     ):
         X = np.arange(100).reshape(10, 10)
         data = pd.DataFrame(X, columns=[f"c{i+1}" for i in range(10)])
-        data.loc[:, "target"] = np.array([0] * 7 + [1] * 3)
+        data["target"] = np.array([0] * 7 + [1] * 3)
 
         actual = PreProcessor.train_selection_validation_split(
             data, train_prop, selection_prop, validation_prop

--- a/tests/preprocessing/test_target_encoder.py
+++ b/tests/preprocessing/test_target_encoder.py
@@ -1,11 +1,12 @@
+
 import pytest
 import pandas as pd
 from sklearn.exceptions import NotFittedError
 
 from cobra.preprocessing.target_encoder import TargetEncoder
 
-
 class TestTargetEncoder:
+
     def test_target_encoder_constructor_weight_value_error(self):
         with pytest.raises(ValueError):
             TargetEncoder(weight=-1)
@@ -18,10 +19,8 @@ class TestTargetEncoder:
     def test_target_encoder_attributes_to_dict(self):
         encoder = TargetEncoder()
 
-        mapping_data = pd.Series(
-            data=[0.333333, 0.50000, 0.666667],
-            index=["negative", "neutral", "positive"],
-        )
+        mapping_data = pd.Series(data=[0.333333, 0.50000, 0.666667],
+                                 index=["negative", "neutral", "positive"])
         mapping_data.index.name = "variable"
 
         encoder._mapping["variable"] = mapping_data
@@ -30,24 +29,20 @@ class TestTargetEncoder:
 
         actual = encoder.attributes_to_dict()
 
-        expected = {
-            "weight": 0.0,
-            "imputation_strategy": "mean",
-            "_global_mean": 0.5,
-            "_mapping": {
-                "variable": {
-                    "negative": 0.333333,
-                    "neutral": 0.50000,
-                    "positive": 0.666667,
-                }
-            },
-        }
+        expected = {"weight": 0.0,
+                    "imputation_strategy": "mean",
+                    "_global_mean": 0.5,
+                    "_mapping": {"variable": {
+                        "negative": 0.333333,
+                        "neutral": 0.50000,
+                        "positive": 0.666667
+                    }}}
 
         assert actual == expected
 
-    @pytest.mark.parametrize(
-        "attribute", ["weight", "mapping"], ids=["test_weight", "test_mapping"]
-    )
+    @pytest.mark.parametrize("attribute",
+                             ["weight", "mapping"],
+                             ids=["test_weight", "test_mapping"])
     def test_target_encoder_set_attributes_from_dict_unfitted(self, attribute):
         encoder = TargetEncoder()
 
@@ -68,24 +63,18 @@ class TestTargetEncoder:
     def test_target_encoder_set_attributes_from_dict(self):
         encoder = TargetEncoder()
 
-        data = {
-            "weight": 0.0,
-            "_global_mean": 0.5,
-            "_mapping": {
-                "variable": {
+        data = {"weight": 0.0,
+                "_global_mean": 0.5,
+                "_mapping": {"variable": {
                     "negative": 0.333333,
                     "neutral": 0.50000,
-                    "positive": 0.666667,
-                }
-            },
-        }
+                    "positive": 0.666667
+                }}}
 
         encoder.set_attributes_from_dict(data)
 
-        expected = pd.Series(
-            data=[0.333333, 0.50000, 0.666667],
-            index=["negative", "neutral", "positive"],
-        )
+        expected = pd.Series(data=[0.333333, 0.50000, 0.666667],
+                             index=["negative", "neutral", "positive"])
         expected.index.name = "variable"
 
         actual = encoder._mapping["variable"]
@@ -94,118 +83,63 @@ class TestTargetEncoder:
 
     # Tests for _fit_column:
     def test_target_encoder_fit_column_binary_classification(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                ],
-                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral'],
+                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
 
         encoder = TargetEncoder()
         encoder._global_mean = 0.5
         actual = encoder._fit_column(X=df.variable, y=df.target)
 
-        expected = pd.Series(
-            data=[0.333333, 0.50000, 0.666667],
-            index=["negative", "neutral", "positive"],
-        )
+        expected = pd.Series(data=[0.333333, 0.50000, 0.666667],
+                             index=["negative", "neutral", "positive"])
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
 
     def test_target_encoder_fit_column_linear_regression(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                    "positive",
-                ],
-                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral', 'positive'],
+                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
 
         encoder = TargetEncoder()
         encoder._global_mean = 0.454545
         actual = encoder._fit_column(X=df.variable, y=df.target)
 
-        expected = pd.Series(
-            data=[-4.666667, 0.250000, 4.500000],
-            index=["negative", "neutral", "positive"],
-        )
+        expected = pd.Series(data=[-4.666667, 0.250000, 4.500000],
+                             index=["negative", "neutral", "positive"])
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
 
     def test_target_encoder_fit_column_global_mean_binary_classification(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                ],
-                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral'],
+                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
 
         encoder = TargetEncoder(weight=1)
         encoder._global_mean = df.target.sum() / df.target.count()  # is 0.5
 
         actual = encoder._fit_column(X=df.variable, y=df.target)
 
-        expected = pd.Series(
-            data=[0.375, 0.500, 0.625], index=["negative", "neutral", "positive"]
-        )
+        expected = pd.Series(data=[0.375, 0.500, 0.625],
+                             index=["negative", "neutral", "positive"])
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
 
     def test_target_encoder_fit_column_global_mean_linear_regression(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                    "positive",
-                ],
-                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral', 'positive'],
+                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
 
         encoder = TargetEncoder(weight=1)
         encoder._global_mean = 0.454545
@@ -215,14 +149,10 @@ class TestTargetEncoder:
         # expected new value:
         # [count of the value * its mean encoding + weight (= 1) * global mean]
         # / [count of the value + weight (=1)].
-        expected = pd.Series(
-            data=[
-                (3 * -4.666667 + 1 * 0.454545) / (3 + 1),
-                (4 * 0.250000 + 1 * 0.454545) / (4 + 1),
-                (4 * 4.500000 + 1 * 0.454545) / (4 + 1),
-            ],
-            index=["negative", "neutral", "positive"],
-        )
+        expected = pd.Series(data=[(3 * -4.666667 + 1 * 0.454545) / (3 + 1),
+                                   (4 * 0.250000 + 1 * 0.454545) / (4 + 1),
+                                   (4 * 4.500000 + 1 * 0.454545) / (4 + 1)],
+                             index=["negative", "neutral", "positive"])
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
@@ -231,31 +161,17 @@ class TestTargetEncoder:
     def test_target_encoder_fit_binary_classification(self):
         # test_target_encoder_fit_column_linear_regression() tested on one
         # column input as a numpy series; this test runs on a dataframe input.
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                ],
-                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral'],
+                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
 
-        expected = pd.Series(
-            data=[0.333333, 0.50000, 0.666667],
-            index=["negative", "neutral", "positive"],
-        )
+        expected = pd.Series(data=[0.333333, 0.50000, 0.666667],
+                             index=["negative", "neutral", "positive"])
         expected.index.name = "variable"
         actual = encoder._mapping["variable"]
 
@@ -264,32 +180,17 @@ class TestTargetEncoder:
     def test_target_encoder_fit_linear_regression(self):
         # test_target_encoder_fit_column_linear_regression() tested on one
         # column input as a numpy series; this test runs on a dataframe input.
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                    "positive",
-                ],
-                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral', 'positive'],
+                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
 
-        expected = pd.Series(
-            data=[-4.666667, 0.250000, 4.500000],
-            index=["negative", "neutral", "positive"],
-        )
+        expected = pd.Series(data=[-4.666667, 0.250000, 4.500000],
+                             index=["negative", "neutral", "positive"])
         expected.index.name = "variable"
         actual = encoder._mapping["variable"]
 
@@ -297,23 +198,11 @@ class TestTargetEncoder:
 
     # Tests for transform method
     def test_target_encoder_transform_when_not_fitted(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                ],
-                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral'],
+                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
@@ -323,40 +212,19 @@ class TestTargetEncoder:
             encoder.transform(data=df, column_names=["variable"])
 
     def test_target_encoder_transform_binary_classification(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                ],
-                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral'],
+                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
 
         expected = df.copy()
-        expected["variable_enc"] = [
-            0.666667,
-            0.666667,
-            0.333333,
-            0.50000,
-            0.333333,
-            0.666667,
-            0.333333,
-            0.50000,
-            0.50000,
-            0.50000,
-        ]
+        expected["variable_enc"] = [0.666667, 0.666667, 0.333333, 0.50000,
+                                    0.333333, 0.666667, 0.333333, 0.50000,
+                                    0.50000, 0.50000]
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
@@ -365,42 +233,19 @@ class TestTargetEncoder:
         pd.testing.assert_frame_equal(actual, expected)
 
     def test_target_encoder_transform_linear_regression(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                    "positive",
-                ],
-                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral', 'positive'],
+                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
 
         expected = df.copy()
-        expected["variable_enc"] = [
-            4.500000,
-            4.500000,
-            -4.666667,
-            0.250000,
-            -4.666667,
-            4.500000,
-            -4.666667,
-            0.250000,
-            0.250000,
-            0.250000,
-            4.500000,
-        ]
+        expected["variable_enc"] = [4.500000, 4.500000, -4.666667, 0.250000,
+                                    -4.666667, 4.500000, -4.666667, 0.250000,
+                                    0.250000, 0.250000, 4.500000]
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
@@ -409,46 +254,23 @@ class TestTargetEncoder:
         pd.testing.assert_frame_equal(actual, expected)
 
     def test_target_encoder_transform_new_category_binary_classification(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                ],
-                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
-            }
-        )
-        df_appended = pd.concat(
-            [df, pd.Series({"variable": "new", "target": 1}).to_frame().T],
-            axis=0,
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral'],
+                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+
+        df_appended = df.append({"variable": "new", "target": 1},
+                                ignore_index=True)
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
         df_appended["variable"] = df_appended["variable"].astype("category")
 
         expected = df_appended.copy()
-        expected["variable_enc"] = [
-            0.666667,
-            0.666667,
-            0.333333,
-            0.50000,
-            0.333333,
-            0.666667,
-            0.333333,
-            0.50000,
-            0.50000,
-            0.50000,
-            0.333333,
-        ]
+        expected["variable_enc"] = [0.666667, 0.666667, 0.333333, 0.50000,
+                                    0.333333, 0.666667, 0.333333, 0.50000,
+                                    0.50000, 0.50000, 0.333333]
 
         encoder = TargetEncoder(imputation_strategy="min")
         encoder.fit(data=df, column_names=["variable"], target_column="target")
@@ -457,49 +279,24 @@ class TestTargetEncoder:
         pd.testing.assert_frame_equal(actual, expected)
 
     def test_target_encoder_transform_new_category_linear_regression(self):
-        df = pd.DataFrame(
-            {
-                "variable": [
-                    "positive",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "negative",
-                    "positive",
-                    "negative",
-                    "neutral",
-                    "neutral",
-                    "neutral",
-                    "positive",
-                ],
-                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
-            }
-        )
+        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
+                                        'neutral', 'negative', 'positive',
+                                        'negative', 'neutral', 'neutral',
+                                        'neutral', 'positive'],
+                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
 
-        df_appended = pd.concat(
-            [df, pd.Series({"variable": "new", "target": 10}).to_frame().T],
-            axis=0,
-        )
+        df_appended = df.append({"variable": "new", "target": 10},
+                                ignore_index=True)
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
         df_appended["variable"] = df_appended["variable"].astype("category")
 
         expected = df_appended.copy()
-        expected["variable_enc"] = [
-            4.500000,
-            4.500000,
-            -4.666667,
-            0.250000,
-            -4.666667,
-            4.500000,
-            -4.666667,
-            0.250000,
-            0.250000,
-            0.250000,
-            4.500000,
-            -4.666667,
-        ]  # min imputation for new value
+        expected["variable_enc"] = [4.500000, 4.500000, -4.666667, 0.250000,
+                                    -4.666667, 4.500000, -4.666667, 0.250000,
+                                    0.250000, 0.250000, 4.500000,
+                                    -4.666667] # min imputation for new value
 
         encoder = TargetEncoder(imputation_strategy="min")
         encoder.fit(data=df, column_names=["variable"], target_column="target")

--- a/tests/preprocessing/test_target_encoder.py
+++ b/tests/preprocessing/test_target_encoder.py
@@ -1,12 +1,11 @@
-
 import pytest
 import pandas as pd
 from sklearn.exceptions import NotFittedError
 
 from cobra.preprocessing.target_encoder import TargetEncoder
 
-class TestTargetEncoder:
 
+class TestTargetEncoder:
     def test_target_encoder_constructor_weight_value_error(self):
         with pytest.raises(ValueError):
             TargetEncoder(weight=-1)
@@ -19,8 +18,10 @@ class TestTargetEncoder:
     def test_target_encoder_attributes_to_dict(self):
         encoder = TargetEncoder()
 
-        mapping_data = pd.Series(data=[0.333333, 0.50000, 0.666667],
-                                 index=["negative", "neutral", "positive"])
+        mapping_data = pd.Series(
+            data=[0.333333, 0.50000, 0.666667],
+            index=["negative", "neutral", "positive"],
+        )
         mapping_data.index.name = "variable"
 
         encoder._mapping["variable"] = mapping_data
@@ -29,20 +30,24 @@ class TestTargetEncoder:
 
         actual = encoder.attributes_to_dict()
 
-        expected = {"weight": 0.0,
-                    "imputation_strategy": "mean",
-                    "_global_mean": 0.5,
-                    "_mapping": {"variable": {
-                        "negative": 0.333333,
-                        "neutral": 0.50000,
-                        "positive": 0.666667
-                    }}}
+        expected = {
+            "weight": 0.0,
+            "imputation_strategy": "mean",
+            "_global_mean": 0.5,
+            "_mapping": {
+                "variable": {
+                    "negative": 0.333333,
+                    "neutral": 0.50000,
+                    "positive": 0.666667,
+                }
+            },
+        }
 
         assert actual == expected
 
-    @pytest.mark.parametrize("attribute",
-                             ["weight", "mapping"],
-                             ids=["test_weight", "test_mapping"])
+    @pytest.mark.parametrize(
+        "attribute", ["weight", "mapping"], ids=["test_weight", "test_mapping"]
+    )
     def test_target_encoder_set_attributes_from_dict_unfitted(self, attribute):
         encoder = TargetEncoder()
 
@@ -63,18 +68,24 @@ class TestTargetEncoder:
     def test_target_encoder_set_attributes_from_dict(self):
         encoder = TargetEncoder()
 
-        data = {"weight": 0.0,
-                "_global_mean": 0.5,
-                "_mapping": {"variable": {
+        data = {
+            "weight": 0.0,
+            "_global_mean": 0.5,
+            "_mapping": {
+                "variable": {
                     "negative": 0.333333,
                     "neutral": 0.50000,
-                    "positive": 0.666667
-                }}}
+                    "positive": 0.666667,
+                }
+            },
+        }
 
         encoder.set_attributes_from_dict(data)
 
-        expected = pd.Series(data=[0.333333, 0.50000, 0.666667],
-                             index=["negative", "neutral", "positive"])
+        expected = pd.Series(
+            data=[0.333333, 0.50000, 0.666667],
+            index=["negative", "neutral", "positive"],
+        )
         expected.index.name = "variable"
 
         actual = encoder._mapping["variable"]
@@ -83,63 +94,118 @@ class TestTargetEncoder:
 
     # Tests for _fit_column:
     def test_target_encoder_fit_column_binary_classification(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral'],
-                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                ],
+                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
+            }
+        )
 
         encoder = TargetEncoder()
         encoder._global_mean = 0.5
         actual = encoder._fit_column(X=df.variable, y=df.target)
 
-        expected = pd.Series(data=[0.333333, 0.50000, 0.666667],
-                             index=["negative", "neutral", "positive"])
+        expected = pd.Series(
+            data=[0.333333, 0.50000, 0.666667],
+            index=["negative", "neutral", "positive"],
+        )
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
 
     def test_target_encoder_fit_column_linear_regression(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral', 'positive'],
-                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                    "positive",
+                ],
+                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
+            }
+        )
 
         encoder = TargetEncoder()
         encoder._global_mean = 0.454545
         actual = encoder._fit_column(X=df.variable, y=df.target)
 
-        expected = pd.Series(data=[-4.666667, 0.250000, 4.500000],
-                             index=["negative", "neutral", "positive"])
+        expected = pd.Series(
+            data=[-4.666667, 0.250000, 4.500000],
+            index=["negative", "neutral", "positive"],
+        )
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
 
     def test_target_encoder_fit_column_global_mean_binary_classification(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral'],
-                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                ],
+                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
+            }
+        )
 
         encoder = TargetEncoder(weight=1)
         encoder._global_mean = df.target.sum() / df.target.count()  # is 0.5
 
         actual = encoder._fit_column(X=df.variable, y=df.target)
 
-        expected = pd.Series(data=[0.375, 0.500, 0.625],
-                             index=["negative", "neutral", "positive"])
+        expected = pd.Series(
+            data=[0.375, 0.500, 0.625], index=["negative", "neutral", "positive"]
+        )
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
 
     def test_target_encoder_fit_column_global_mean_linear_regression(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral', 'positive'],
-                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                    "positive",
+                ],
+                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
+            }
+        )
 
         encoder = TargetEncoder(weight=1)
         encoder._global_mean = 0.454545
@@ -149,10 +215,14 @@ class TestTargetEncoder:
         # expected new value:
         # [count of the value * its mean encoding + weight (= 1) * global mean]
         # / [count of the value + weight (=1)].
-        expected = pd.Series(data=[(3 * -4.666667 + 1 * 0.454545) / (3 + 1),
-                                   (4 * 0.250000 + 1 * 0.454545) / (4 + 1),
-                                   (4 * 4.500000 + 1 * 0.454545) / (4 + 1)],
-                             index=["negative", "neutral", "positive"])
+        expected = pd.Series(
+            data=[
+                (3 * -4.666667 + 1 * 0.454545) / (3 + 1),
+                (4 * 0.250000 + 1 * 0.454545) / (4 + 1),
+                (4 * 4.500000 + 1 * 0.454545) / (4 + 1),
+            ],
+            index=["negative", "neutral", "positive"],
+        )
         expected.index.name = "variable"
 
         pd.testing.assert_series_equal(actual, expected)
@@ -161,17 +231,31 @@ class TestTargetEncoder:
     def test_target_encoder_fit_binary_classification(self):
         # test_target_encoder_fit_column_linear_regression() tested on one
         # column input as a numpy series; this test runs on a dataframe input.
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral'],
-                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                ],
+                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
+            }
+        )
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
 
-        expected = pd.Series(data=[0.333333, 0.50000, 0.666667],
-                             index=["negative", "neutral", "positive"])
+        expected = pd.Series(
+            data=[0.333333, 0.50000, 0.666667],
+            index=["negative", "neutral", "positive"],
+        )
         expected.index.name = "variable"
         actual = encoder._mapping["variable"]
 
@@ -180,17 +264,32 @@ class TestTargetEncoder:
     def test_target_encoder_fit_linear_regression(self):
         # test_target_encoder_fit_column_linear_regression() tested on one
         # column input as a numpy series; this test runs on a dataframe input.
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral', 'positive'],
-                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                    "positive",
+                ],
+                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
+            }
+        )
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
 
-        expected = pd.Series(data=[-4.666667, 0.250000, 4.500000],
-                             index=["negative", "neutral", "positive"])
+        expected = pd.Series(
+            data=[-4.666667, 0.250000, 4.500000],
+            index=["negative", "neutral", "positive"],
+        )
         expected.index.name = "variable"
         actual = encoder._mapping["variable"]
 
@@ -198,11 +297,23 @@ class TestTargetEncoder:
 
     # Tests for transform method
     def test_target_encoder_transform_when_not_fitted(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral'],
-                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                ],
+                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
+            }
+        )
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
@@ -212,19 +323,40 @@ class TestTargetEncoder:
             encoder.transform(data=df, column_names=["variable"])
 
     def test_target_encoder_transform_binary_classification(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral'],
-                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                ],
+                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
+            }
+        )
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
 
         expected = df.copy()
-        expected["variable_enc"] = [0.666667, 0.666667, 0.333333, 0.50000,
-                                    0.333333, 0.666667, 0.333333, 0.50000,
-                                    0.50000, 0.50000]
+        expected["variable_enc"] = [
+            0.666667,
+            0.666667,
+            0.333333,
+            0.50000,
+            0.333333,
+            0.666667,
+            0.333333,
+            0.50000,
+            0.50000,
+            0.50000,
+        ]
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
@@ -233,19 +365,42 @@ class TestTargetEncoder:
         pd.testing.assert_frame_equal(actual, expected)
 
     def test_target_encoder_transform_linear_regression(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral', 'positive'],
-                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                    "positive",
+                ],
+                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
+            }
+        )
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
 
         expected = df.copy()
-        expected["variable_enc"] = [4.500000, 4.500000, -4.666667, 0.250000,
-                                    -4.666667, 4.500000, -4.666667, 0.250000,
-                                    0.250000, 0.250000, 4.500000]
+        expected["variable_enc"] = [
+            4.500000,
+            4.500000,
+            -4.666667,
+            0.250000,
+            -4.666667,
+            4.500000,
+            -4.666667,
+            0.250000,
+            0.250000,
+            0.250000,
+            4.500000,
+        ]
 
         encoder = TargetEncoder()
         encoder.fit(data=df, column_names=["variable"], target_column="target")
@@ -254,23 +409,46 @@ class TestTargetEncoder:
         pd.testing.assert_frame_equal(actual, expected)
 
     def test_target_encoder_transform_new_category_binary_classification(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral'],
-                           'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
-
-        df_appended = df.append({"variable": "new", "target": 1},
-                                ignore_index=True)
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                ],
+                "target": [1, 1, 0, 0, 1, 0, 0, 0, 1, 1],
+            }
+        )
+        df_appended = pd.concat(
+            [df, pd.Series({"variable": "new", "target": 1}).to_frame().T],
+            axis=0,
+        )
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
         df_appended["variable"] = df_appended["variable"].astype("category")
 
         expected = df_appended.copy()
-        expected["variable_enc"] = [0.666667, 0.666667, 0.333333, 0.50000,
-                                    0.333333, 0.666667, 0.333333, 0.50000,
-                                    0.50000, 0.50000, 0.333333]
+        expected["variable_enc"] = [
+            0.666667,
+            0.666667,
+            0.333333,
+            0.50000,
+            0.333333,
+            0.666667,
+            0.333333,
+            0.50000,
+            0.50000,
+            0.50000,
+            0.333333,
+        ]
 
         encoder = TargetEncoder(imputation_strategy="min")
         encoder.fit(data=df, column_names=["variable"], target_column="target")
@@ -279,24 +457,49 @@ class TestTargetEncoder:
         pd.testing.assert_frame_equal(actual, expected)
 
     def test_target_encoder_transform_new_category_linear_regression(self):
-        df = pd.DataFrame({'variable': ['positive', 'positive', 'negative',
-                                        'neutral', 'negative', 'positive',
-                                        'negative', 'neutral', 'neutral',
-                                        'neutral', 'positive'],
-                           'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
+        df = pd.DataFrame(
+            {
+                "variable": [
+                    "positive",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "negative",
+                    "positive",
+                    "negative",
+                    "neutral",
+                    "neutral",
+                    "neutral",
+                    "positive",
+                ],
+                "target": [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4],
+            }
+        )
 
-        df_appended = df.append({"variable": "new", "target": 10},
-                                ignore_index=True)
+        df_appended = pd.concat(
+            [df, pd.Series({"variable": "new", "target": 10}).to_frame().T],
+            axis=0,
+        )
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
         df_appended["variable"] = df_appended["variable"].astype("category")
 
         expected = df_appended.copy()
-        expected["variable_enc"] = [4.500000, 4.500000, -4.666667, 0.250000,
-                                    -4.666667, 4.500000, -4.666667, 0.250000,
-                                    0.250000, 0.250000, 4.500000,
-                                    -4.666667] # min imputation for new value
+        expected["variable_enc"] = [
+            4.500000,
+            4.500000,
+            -4.666667,
+            0.250000,
+            -4.666667,
+            4.500000,
+            -4.666667,
+            0.250000,
+            0.250000,
+            0.250000,
+            4.500000,
+            -4.666667,
+        ]  # min imputation for new value
 
         encoder = TargetEncoder(imputation_strategy="min")
         encoder.fit(data=df, column_names=["variable"], target_column="target")

--- a/tests/preprocessing/test_target_encoder.py
+++ b/tests/preprocessing/test_target_encoder.py
@@ -260,8 +260,7 @@ class TestTargetEncoder:
                                         'neutral'],
                            'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
 
-        df_appended = df.append({"variable": "new", "target": 1},
-                                ignore_index=True)
+        df_appended = pd.concat([df, pd.DataFrame({"variable": "new", "target": 1}, index=[len(df)])], ignore_index=True)
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
@@ -285,8 +284,7 @@ class TestTargetEncoder:
                                         'neutral', 'positive'],
                            'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
 
-        df_appended = df.append({"variable": "new", "target": 10},
-                                ignore_index=True)
+        df_appended = pd.concat([df, pd.DataFrame({"variable": "new", "target": 10}, index=[len(df)])], ignore_index=True)
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")


### PR DESCRIPTION
# Story Title

Fixing FutureWarnings (https://github.com/PythonPredictions/cobra/issues/156)

## Changes made

- Changes the syntax of assigning a new column from df.loc[:,"col_name"] = something to df["col_name"] = something 
- Replaces the depreciated inplace argument for some methods

## How does the solution address the problem

This PR will update the syntax

## Comment
No test were written to automatically catch FutureWarnings. FutureWarnings are displayed by default so they are already shown when running the tests.

## Linked issues

Resolves #156 
Linked to #160 