### PR TITLE
2023-03 release patches

### DIFF
--- a/.github/workflows/master_CI.yaml
+++ b/.github/workflows/master_CI.yaml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install pylint pytest pytest-mock pytest-cov
+        python -m pip install -r requirements.dev.txt
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
# 2023-03 release patches

No issue linked, PR to do patches before releasing 2023-03.
Necessary to get PR #162 passing the unit tests. Couldn't do the changes in that PR "because develop was protected"