### PR TITLE
Short term pandas 2.0 support

### DIFF
--- a/.github/workflows/development_CI.yaml
+++ b/.github/workflows/development_CI.yaml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install pylint pytest pytest-mock pytest-cov
+        python -m pip install -r requirements.dev.txt
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/master_CI.yaml
+++ b/.github/workflows/master_CI.yaml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install pylint pytest pytest-mock pytest-cov
+        python -m pip install -r requirements.dev.txt
 
     - name: Test with pytest
       run: |

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,3 +4,4 @@ pydocstyle>=6.1.1
 pylint>=2.13.7
 pytest>=7.1.1
 pytest-mock>=3.7.0
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.19.4
-pandas>=1.1.5
+pandas>=1.1.5,<2.0.0
 scipy>=1.5.4
 scikit-learn>=1.2.0
 matplotlib>=3.4.3

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ README = (ROOT / "README.rst").read_text()
 setup(
     name="pythonpredictions-cobra",
     version=__version__,
-    description=("A Python package to build predictive linear and logistic regression "
-                 "models focused on performance and interpretation."),
+    description=("A Python package to build predictive linear and logistic "
+                 "regression models focused on performance and "
+                 "interpretation."),
     long_description=README,
     long_description_content_type="text/x-rst",
     packages=find_packages(include=["cobra", "cobra.*"]),
@@ -24,7 +25,7 @@ setup(
     author_email="cobra@pythonpredictions.com",
     install_requires=[
         "numpy>=1.19.4",
-        "pandas>=1.1.5",
+        "pandas>=1.1.5,<2.0",
         "scipy>=1.5.4",
         "scikit-learn>=0.24.1",
         "matplotlib>=3.4.3",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email="cobra@pythonpredictions.com",
     install_requires=[
         "numpy>=1.19.4",
-        "pandas>=1.1.5,<2.0",
+        "pandas>=1.1.5,<2.0.0",
         "scipy>=1.5.4",
         "scikit-learn>=0.24.1",
         "matplotlib>=3.4.3",


### PR DESCRIPTION
# Story Title

Issue: [Short term pandas 2.0 support: avoid pandas 2.0 installation](https://github.com/PythonPredictions/cobra/issues/159)

## Changes made

- enforcing pandas < 2.0 in requirements.txt and setup.py

## How does the solution address the problem

This PR will enforce pandas < 2.0 as a short term fix, 

## Linked issues

Resolves #159 