### PR TITLE
Refactor/compute univariate preselection

### DIFF
--- a/cobra/model_building/univariate_selection.py
+++ b/cobra/model_building/univariate_selection.py
@@ -1,9 +1,9 @@
 
 import pandas as pd
 from sklearn.metrics import roc_auc_score, mean_squared_error
-from numpy import sqrt
 
 import cobra.utils as utils
+
 
 def compute_univariate_preselection(target_enc_train_data: pd.DataFrame,
                                     target_enc_selection_data: pd.DataFrame,
@@ -99,6 +99,7 @@ def compute_univariate_preselection(target_enc_train_data: pd.DataFrame,
     df_score = pd.DataFrame(result)
 
     # TODO: This should be `if scoring method is error based` instead of classification vs regression
+    # This opens the door to customised scoring methods
     if model_type == "classification":
         # Filter based on min. AUC
         score_thresh = df_score.loc[:, f"{scoring_method_str} selection"] > preselect_auc_threshold
@@ -130,6 +131,7 @@ def compute_univariate_preselection(target_enc_train_data: pd.DataFrame,
         df_out = df_score.sort_values(by=f"{scoring_method_str} selection", ascending=True).reset_index(drop=True)  # lower is better
     return df_out
 
+
 def get_preselected_predictors(df_metric: pd.DataFrame) -> list:
     """Wrapper function to extract a list of predictors from df_metric.
 
@@ -156,6 +158,7 @@ def get_preselected_predictors(df_metric: pd.DataFrame) -> list:
                           .predictor.tolist())
 
     return [col + "_enc" for col in predictor_list]
+
 
 def compute_correlations(target_enc_train_data: pd.DataFrame,
                          predictors: list) -> pd.DataFrame:

--- a/tests/model_building/test_univariate_selection.py
+++ b/tests/model_building/test_univariate_selection.py
@@ -1,8 +1,11 @@
 
 import pandas as pd
+import pytest
 
 from cobra.model_building import univariate_selection
 
+
+@pytest.fixture
 def mock_data():
     return pd.DataFrame({"var1_enc": [0.42] * 10,
                          "var2_enc": [0.94] * 10,
@@ -10,9 +13,8 @@ def mock_data():
 
 class TestUnivariateSelection:
 
-    def test_preselection_classification(self):
-
-        X = mock_data()
+    def test_preselection_classification(self, mock_data: pd.DataFrame):
+        X = mock_data
         y = pd.DataFrame([1] * 5 + [0] * 5, columns=["target"])
 
         basetable = pd.concat([y, X], axis=1)
@@ -29,14 +31,11 @@ class TestUnivariateSelection:
 
         assert all(c in df_auc.columns for c in ["AUC train", "AUC selection"])
 
-        preselected_predictors = (univariate_selection
-                                  .get_preselected_predictors(df_auc))
-
+        preselected_predictors = univariate_selection.get_preselected_predictors(df_auc)
         assert preselected_predictors == ["var1_enc", "var2_enc", "var3_enc"]
 
-    def test_preselection_regression(self):
-
-        X = mock_data()
+    def test_preselection_regression(self, mock_data: pd.DataFrame):
+        X = mock_data
         y = pd.DataFrame([6.0, 9.0, 4.2, 5.5, 0.7, 1.9, 8.7, 8.0, 2.0, 7.2], columns=["target"])
 
         basetable = pd.concat([y, X], axis=1)
@@ -53,7 +52,5 @@ class TestUnivariateSelection:
 
         assert all(c in df_rmse.columns for c in ["RMSE train", "RMSE selection"])
 
-        preselected_predictors = (univariate_selection
-                                  .get_preselected_predictors(df_rmse))
-
+        preselected_predictors = univariate_selection.get_preselected_predictors(df_rmse)
         assert preselected_predictors == ["var2_enc", "var3_enc"]

--- a/tests/model_building/test_univariate_selection.py
+++ b/tests/model_building/test_univariate_selection.py
@@ -54,3 +54,85 @@ class TestUnivariateSelection:
 
         preselected_predictors = univariate_selection.get_preselected_predictors(df_rmse)
         assert preselected_predictors == ["var2_enc", "var3_enc"]
+
+    def test_filter_preselection_error_based(self):
+        """Test filtering preselection data for an error-based metric."""
+        test_input = pd.DataFrame(
+            [
+                [0.1, 0.1],
+                [0.2, 0.2],
+                [0.3, 0.6],
+                [0.4, 0.4],
+                [0.5, 0.5],
+                [0.6, 0.6],
+                [0.7, 0.7],
+                [0.8, 0.8],
+                [0.9, 0.9],
+                [1.0, 1.0],
+            ],
+            columns=["RMSE train", "RMSE selection"]
+        )
+        result = univariate_selection.filter_preselection_error_based(
+            test_input,
+            preselect_threshold=0.65,
+            preselect_overtrain=0.2,
+            scoring_method="RMSE"
+        )
+
+        target = pd.DataFrame(
+            [
+                [0.1, 0.1, True],
+                [0.2, 0.2, True],
+                [0.4, 0.4, True],
+                [0.5, 0.5, True],
+                [0.3, 0.6, False],
+                [0.6, 0.6, True],
+                [0.7, 0.7, False],
+                [0.8, 0.8, False],
+                [0.9, 0.9, False],
+                [1.0, 1.0, False],
+            ],
+            columns=["RMSE train", "RMSE selection", "preselection"]
+        )
+        assert target.equals(result)
+
+    def test_filter_preselection_score_based(self):
+        """Test filtering preselection data for a score-based metric."""
+        test_input = pd.DataFrame(
+            [
+                [0.1, 0.1],
+                [0.2, 0.2],
+                [0.3, 0.6],
+                [0.4, 0.4],
+                [0.5, 0.5],
+                [0.6, 0.6],
+                [0.7, 0.7],
+                [0.8, 0.8],
+                [0.9, 0.9],
+                [1.0, 0.7],
+            ],
+            columns=["AUC train", "AUC selection"]
+        )
+        result = univariate_selection.filter_preselection_score_based(
+            test_input,
+            preselect_threshold=0.65,
+            preselect_overtrain=0.2,
+            scoring_method="AUC"
+        )
+
+        target = pd.DataFrame(
+            [
+                [0.9, 0.9, True],
+                [0.8, 0.8, True],
+                [0.7, 0.7, True],
+                [1.0, 0.7, False],
+                [0.3, 0.6, False],
+                [0.6, 0.6, False],
+                [0.5, 0.5, False],
+                [0.4, 0.4, False],
+                [0.2, 0.2, False],
+                [0.1, 0.1, False],
+            ],
+            columns=["AUC train", "AUC selection", "preselection"]
+        )
+        assert target.equals(result)


### PR DESCRIPTION
Resolves #171 
This PR refactors the existing `compute_univariate_preselection` method according to the DIY principle.
It also prepares for sending a custom scoring metric.
