### PR TITLE
fix(FutureWarnings): replace .append by pd.concat

### DIFF
--- a/tests/preprocessing/test_target_encoder.py
+++ b/tests/preprocessing/test_target_encoder.py
@@ -309,9 +309,9 @@ class TestTargetEncoder:
                                         'neutral', 'positive'],
                            'target': [5, 4, -5, 0, -4, 5, -5, 0, 1, 0, 4]})
 
-        df_appended = df.append({"variable": "new", "target": 10},
-                                ignore_index=True)
-
+        new_row = pd.DataFrame({"variable": ["new"], "target": [10]})
+        df_appended = pd.concat([df, new_row], ignore_index=True)
+        
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")
         df_appended["variable"] = df_appended["variable"].astype("category")
@@ -335,8 +335,8 @@ class TestTargetEncoder:
                                         'neutral'],
                            'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
 
-        df_appended = df.append({"variable": "new", "target": 1},
-                                ignore_index=True)
+        new_row = pd.DataFrame({"variable": ["new"], "target": [1]})
+        df_appended = pd.concat([df, new_row], ignore_index=True)
 
         # inputs of TargetEncoder will be of dtype category
         df["variable"] = df["variable"].astype("category")


### PR DESCRIPTION
# Story Title

[Update code to not raise any FutureWarnings](https://github.com/PythonPredictions/cobra/issues/190)

## Changes made

- replaced `df.append(new_row)`  by `pd.concat([df, new_row)`

## How does the solution address the problem

We use the `pd.concat` method to do the same. 
see: [Pandas docs](https://pandas.pydata.org/pandas-docs/version/1.5/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append)

## Linked issues

Resolves #190